### PR TITLE
!hotfix: 예약 시간 검증 객체 수정

### DIFF
--- a/storeReservation/src/main/java/com/store/reservation/global/reservation/facade/ReservationFacadeService.java
+++ b/storeReservation/src/main/java/com/store/reservation/global/reservation/facade/ReservationFacadeService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static com.store.reservation.reservation.exception.reservation.ReservationError.*;
@@ -46,7 +47,7 @@ public class ReservationFacadeService {
     public void reserve(Long storeId, Long customerId, ReservationDto reservationDto) {
         MemberInformation customer = memberService.searchBy(customerId);
         Store store = storeService.searchStoreByCustomer(storeId);
-        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDate.now(), LocalTime.now());
+        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDateTime.now());
 
         if (!store.isCorrectReservationTime(reservationDto.getReservationTime())) {
             throw new ReservationRuntimeException(ILLEGAL_RESERVATION_TIME);

--- a/storeReservation/src/main/java/com/store/reservation/reservation/domain/model/ReservationPolicy.java
+++ b/storeReservation/src/main/java/com/store/reservation/reservation/domain/model/ReservationPolicy.java
@@ -1,42 +1,25 @@
 package com.store.reservation.reservation.domain.model;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class ReservationPolicy {
 
-    private final LocalTime currentTime;
-    private final LocalDate currentDate;
+    private final LocalDateTime current;
 
-    public ReservationPolicy(LocalDate currentDate, LocalTime currentTime) {
-        this.currentTime = currentTime;
-        this.currentDate = currentDate;
+    public ReservationPolicy(LocalDateTime current) {
+        this.current = current;
     }
 
     public boolean isValidReservationTime(int limit, LocalDate reservationDate, LocalTime reservationTime) {
-        return isAfterThanCurrentDate(reservationDate)
-                && isAfterThanCurrentTime(limit, reservationTime);
-    }
-
-    private boolean isAfterThanCurrentTime(int limit, LocalTime reservationTime) {
-        return this.currentTime.isBefore(reservationTime.plusMinutes(limit));
-    }
-
-    private boolean isAfterThanCurrentDate(LocalDate reservationDate) {
-        return this.currentDate.equals(reservationDate) || this.currentDate.isBefore(reservationDate);
-    }
-
-    private boolean isBeforeThanCurrentTime(int limit, LocalTime localTime){
-        return this.currentTime.plusMinutes(limit).isAfter(localTime);
-    }
-
-    private boolean equalsThanCurrentDate(LocalDate localDate){
-        return this.currentDate.equals(localDate);
+        return this.current.plusMinutes(limit).isBefore(LocalDateTime.of(reservationDate, reservationTime));
     }
 
     public boolean isValidArrivalTime(int limit, LocalDate reservationDate, LocalTime reservationTime) {
-        return (isBeforeThanCurrentTime(limit, reservationTime)
-                && isAfterThanCurrentTime(limit, reservationTime))
-                && equalsThanCurrentDate(reservationDate);
+        LocalDateTime reservationDateTime = LocalDateTime.of(reservationDate, reservationTime);
+        return (reservationDateTime.plusMinutes(limit).isAfter(this.current) || reservationDateTime.plusMinutes(limit).equals(this.current))
+                && (reservationDateTime.minusMinutes(limit).isBefore(this.current) || reservationDateTime.minusMinutes(limit).equals(this.current));
+
     }
 }

--- a/storeReservation/src/main/java/com/store/reservation/reservation/service/ReservationService.java
+++ b/storeReservation/src/main/java/com/store/reservation/reservation/service/ReservationService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static com.store.reservation.reservation.constants.state.ReservationState.APPROVAL;
@@ -45,7 +46,7 @@ public class ReservationService {
 
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationRuntimeException(NO_SUCH_RESERVATION));
-        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDate.now(), LocalTime.now());
+        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDateTime.now());
         if (!reservationPolicy.isValidReservationTime(0, reservation.getTime().getReservedDate(),
                 reservation.getTime().getReservedTime())) {
             throw new ReservationPolicyRuntimeException(INVALID_RESERVATION_TIME);
@@ -56,7 +57,7 @@ public class ReservationService {
     public void updateArrivalState(Long reservationId, ArrivalState arrivalState) {
         Reservation reservation = reservationRepository.findByIdAndState_ReservationState(reservationId, APPROVAL)
                 .orElseThrow(() -> new ReservationRuntimeException(NO_SUCH_RESERVATION));
-        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDate.now(), LocalTime.now());
+        ReservationPolicy reservationPolicy = new ReservationPolicy(LocalDateTime.now());
         if (reservationPolicy.isValidArrivalTime(TEN.getMinute(), reservation.getTime().getReservedDate(),
                 reservation.getTime().getReservedTime())) {
             throw new ReservationPolicyRuntimeException(INVALID_RESERVATION_TIME);


### PR DESCRIPTION
# 예약 시간 객체 수정

## 시간 비교 로직의 문제점 수정
### 문제점
- 시간 비교 로직에서 예약 날짜와 예약 시간에 대해 각각을 조건에 맞게 검증하려고 했으나 날짜는 현재 날짜보다 이후이면서 예약 시간이 현재 시간보다 작은 경우 예약이 안되는 문제 발생 
### 수정한 사항
- 예약 날짜와 시간을 같이 비교하기 위해 날짜와 시간을 같이 비교할 수 있는 자료형으로 수정
- 예약 시간 검증 객체가 사용되는 예약 서비스와 예약 퍼사드의 예약 시간 검증 객체의 초기화 부분 수정  