### PR TITLE
로그인, 로그아웃, 접근 토큰 재발급 테스트

### DIFF
--- a/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/domain/RefreshToken.java
+++ b/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/domain/RefreshToken.java
@@ -23,4 +23,8 @@ public class RefreshToken {
         this.refreshToken = refreshToken;
         this.expiration = expiration;
     }
+
+    public boolean isSameToken(String refreshToken){
+        return this.refreshToken.equals(refreshToken);
+    }
 }

--- a/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/exception/TokenErrorCode.java
+++ b/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/exception/TokenErrorCode.java
@@ -10,8 +10,9 @@ public enum TokenErrorCode {
     SUSPICIOUS_ACTION("의심스러운 행위가 감지되었습니다."),
 
     TOKEN_EXPIRED("토큰이 만료되었습니다."),
-    EMPTY_TOKEN("토큰 값을 찾을 수 없습니다."),
-    INVALID_PREFIX("헤더 값은 올바르지 않습니다.");
+    EMPTY_TOKEN("토큰이 없습니다."),
+    INVALID_PREFIX("헤더 값은 올바르지 않습니다."),
+    INVALID_ACCESS("부적절한 접근입니다.");
 
     private final String description;
 }

--- a/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/service/RefreshTokenService.java
+++ b/storeReservation/src/main/java/com/store/reservation/auth/refreshToken/service/RefreshTokenService.java
@@ -31,5 +31,8 @@ public class RefreshTokenService {
     public void delete(String email) {
         refreshTokenRepository.deleteById(email);
     }
-
+    public boolean isSameToken(String email, String requestedRefreshToken){
+        RefreshToken refreshToken = refreshTokenRepository.findById(email).orElseThrow(()->new TokenException(NO_SUCH_TOKEN));
+        return refreshToken.isSameToken(requestedRefreshToken);
+    }
 }

--- a/storeReservation/src/main/java/com/store/reservation/exception/GlobalExceptionHandler.java
+++ b/storeReservation/src/main/java/com/store/reservation/exception/GlobalExceptionHandler.java
@@ -16,7 +16,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ApiResponse<String> handleException(Exception e) {
-        return error(e.getCause().toString(), HttpStatus.BAD_REQUEST.toString());
+        return error(e.getClass().toString(), HttpStatus.BAD_REQUEST.toString());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<String> handleRuntimeException(RuntimeException runtimeException) {
+        return error(runtimeException.getClass().toString(), HttpStatus.BAD_REQUEST.toString());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/storeReservation/src/main/java/com/store/reservation/member/controller/MemberController.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.store.reservation.member.controller;
 
 import com.store.reservation.apiResponse.ApiResponse;
+import com.store.reservation.member.dto.ReissueTokenDto;
 import com.store.reservation.member.dto.SignInDto;
 import com.store.reservation.member.dto.SignUpDto;
 import com.store.reservation.member.dto.TokenDto;
@@ -53,8 +54,9 @@ public class MemberController {
     @Operation(summary = "접근 토큰 재발급하기",
             description = "접근 토큰과 재발급 토큰으로 만료된 접근 토큰을 갱신",
             tags = "member-api")
-    public ApiResponse<String> reissue(@RequestHeader("RefreshToken") String refreshToken) {
-        return ApiResponse.success(this.customerService.reissue(refreshToken, new Date()));
+    public ApiResponse<String> reissue(@RequestHeader("RefreshToken") String refreshToken,
+                                       @RequestBody ReissueTokenDto reissueTokenDto) {
+        return ApiResponse.success(this.customerService.reissue(refreshToken, reissueTokenDto));
     }
 
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/controller/MemberController.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/controller/MemberController.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Date;
 
 @RestController
 @RequestMapping("/member")

--- a/storeReservation/src/main/java/com/store/reservation/member/domain/MemberInformation.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/domain/MemberInformation.java
@@ -34,7 +34,7 @@ public class MemberInformation extends BaseEntity {
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles;
 
-    public boolean isSame(Long id){
+    public boolean isSame(Long id) {
         return this.id.equals(id);
     }
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/dto/ReissueTokenDto.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/dto/ReissueTokenDto.java
@@ -6,8 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
 import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -18,7 +19,10 @@ public class ReissueTokenDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime today;
 
-    public Date getDate(){
+    public Date getDate() {
+        if (Objects.isNull(this.today)) {
+            return null;
+        }
         return java.sql.Timestamp.valueOf(today);
     }
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/dto/ReissueTokenDto.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/dto/ReissueTokenDto.java
@@ -2,35 +2,23 @@ package com.store.reservation.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.store.reservation.member.validation.email.Email;
-import com.store.reservation.member.validation.password.Password;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.util.Date;
-import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
-public class SignInDto {
+@AllArgsConstructor
+public class ReissueTokenDto {
     @Email
     private String email;
-    @Password
-    private String password;
-    @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime today;
 
-    public Date getDate() {
-        if (Objects.isNull(this.today)) {
-            return null;
-        }
-        return java.sql.Timestamp.valueOf(this.today);
+    public Date getDate(){
+        return java.sql.Timestamp.valueOf(today);
     }
-
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/exception/MemberError.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/exception/MemberError.java
@@ -11,7 +11,9 @@ public enum MemberError {
     NO_SUCH_MEMBER("회원이 존재하지 않습니다"),
     PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다"),
     ACCESS_DENIED("올바른 데이터 접근이 아닙니다."),
-    TOKEN_EXPIRED("토큰이 만료되었습니다.");
+    TOKEN_EXPIRED("토큰이 만료되었습니다."),
+    TIME_EMPTY("시간 값이 비어있습니다.")
+    ;
 
     private final String description;
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/security/jwt/Jwt.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/security/jwt/Jwt.java
@@ -1,6 +1,5 @@
 package com.store.reservation.member.security.jwt;
 
-import com.store.reservation.common.constants.TokenExpirationConstant;
 import com.store.reservation.member.security.userDetails.SecurityUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/storeReservation/src/main/java/com/store/reservation/member/security/provider/JWTProvider.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/security/provider/JWTProvider.java
@@ -1,6 +1,7 @@
 package com.store.reservation.member.security.provider;
 
 
+import com.store.reservation.auth.refreshToken.exception.TokenErrorCode;
 import com.store.reservation.auth.refreshToken.exception.TokenException;
 import com.store.reservation.auth.refreshToken.service.RefreshTokenService;
 import com.store.reservation.common.constants.TokenExpirationConstant;
@@ -32,18 +33,21 @@ public class JWTProvider {
 
     public String generateAccessToken(String email, Date today) {
         SecurityUser securityUser = customUserDetailService.loadUserByUsername(email);
-        return jwt.generate(securityUser, today, tokenExpirationConstant.getAccessTokenExpiredDate(today));
+        return this.jwt.generate(securityUser, today, tokenExpirationConstant.getAccessTokenExpiredDate(today));
     }
 
     public String issueRefreshToken(String email, Date today) {
         SecurityUser securityUser = customUserDetailService.loadUserByUsername(email);
-        String refreshToken = jwt.generate(securityUser, today, tokenExpirationConstant.getRefreshTokenExpiredDate(today));
+        String refreshToken = this.jwt.generate(securityUser, today, tokenExpirationConstant.getRefreshTokenExpiredDate(today));
         this.refreshTokenService.save(email, refreshToken, tokenExpirationConstant.getRefreshTokenExpiredMinute());
         return refreshToken;
     }
 
-    public boolean isExpired(String userEmail) {
-        return this.refreshTokenService.isRefreshTokenExpired(userEmail);
+    public String reissue(String email, String refreshToken, Date today) {
+        if(!this.refreshTokenService.isSameToken(email, refreshToken)){
+            throw new TokenException(INVALID_ACCESS);
+        }
+        return generateAccessToken(email, today);
     }
 
 
@@ -52,7 +56,7 @@ public class JWTProvider {
             throw new TokenException(EMPTY_TOKEN);
         }
         String token = this.eliminatePrefix(headerValue);
-        String userName = jwt.getUserName(token);
+        String userName = this.jwt.getUserName(token);
         UserDetails userDetails = this.customUserDetailService.loadUserByUsername(userName);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
@@ -77,6 +81,8 @@ public class JWTProvider {
     }
 
     public void deleteRefreshToken(String email) {
-        this.refreshTokenService.delete(email);
+        if(!this.refreshTokenService.isRefreshTokenExpired(email)){
+            this.refreshTokenService.delete(email);
+        }
     }
 }

--- a/storeReservation/src/main/java/com/store/reservation/member/security/provider/JWTProvider.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/security/provider/JWTProvider.java
@@ -1,7 +1,6 @@
 package com.store.reservation.member.security.provider;
 
 
-import com.store.reservation.auth.refreshToken.exception.TokenErrorCode;
 import com.store.reservation.auth.refreshToken.exception.TokenException;
 import com.store.reservation.auth.refreshToken.service.RefreshTokenService;
 import com.store.reservation.common.constants.TokenExpirationConstant;
@@ -44,7 +43,7 @@ public class JWTProvider {
     }
 
     public String reissue(String email, String refreshToken, Date today) {
-        if(!this.refreshTokenService.isSameToken(email, refreshToken)){
+        if (!this.refreshTokenService.isSameToken(email, refreshToken)) {
             throw new TokenException(INVALID_ACCESS);
         }
         return generateAccessToken(email, today);
@@ -81,7 +80,7 @@ public class JWTProvider {
     }
 
     public void deleteRefreshToken(String email) {
-        if(!this.refreshTokenService.isRefreshTokenExpired(email)){
+        if (!this.refreshTokenService.isRefreshTokenExpired(email)) {
             this.refreshTokenService.delete(email);
         }
     }

--- a/storeReservation/src/main/java/com/store/reservation/member/security/userDetailService/CustomUserDetailService.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/security/userDetailService/CustomUserDetailService.java
@@ -4,7 +4,6 @@ import com.store.reservation.member.domain.MemberInformation;
 import com.store.reservation.member.repository.MemberInformationRepository;
 import com.store.reservation.member.security.userDetails.SecurityUser;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;

--- a/storeReservation/src/main/java/com/store/reservation/member/service/MemberService.java
+++ b/storeReservation/src/main/java/com/store/reservation/member/service/MemberService.java
@@ -15,7 +15,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
 import java.util.Objects;
 
 import static com.store.reservation.member.exception.MemberError.*;
@@ -54,7 +53,7 @@ public class MemberService {
             throw new MemberRuntimeException(PASSWORD_NOT_MATCH);
         }
 
-        if(Objects.isNull(signInRequest.getDate())){
+        if (Objects.isNull(signInRequest.getDate())) {
             throw new MemberRuntimeException(TIME_EMPTY);
         }
 
@@ -74,10 +73,10 @@ public class MemberService {
     }
 
     public String reissue(String refreshToken, ReissueTokenDto reissueTokenDto) {
-        if(refreshToken.isEmpty()){
+        if (refreshToken.isEmpty()) {
             throw new TokenException(TokenErrorCode.EMPTY_TOKEN);
         }
-        if(Objects.isNull(reissueTokenDto.getDate())){
+        if (Objects.isNull(reissueTokenDto.getDate())) {
             throw new MemberRuntimeException(TIME_EMPTY);
         }
         return this.jwtProvider.reissue(reissueTokenDto.getEmail(), refreshToken, reissueTokenDto.getDate());

--- a/storeReservation/src/test/java/com/store/reservation/member/controller/MemberControllerTest.java
+++ b/storeReservation/src/test/java/com/store/reservation/member/controller/MemberControllerTest.java
@@ -1,6 +1,8 @@
 package com.store.reservation.member.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.store.reservation.annotation.WithCustomer;
 import com.store.reservation.config.TestSecurityConfig;
 import com.store.reservation.member.domain.type.Role;
 import com.store.reservation.member.dto.SignInDto;
@@ -48,7 +50,7 @@ class MemberControllerTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @DisplayName("회원 가입")
+    @DisplayName("회원가입 API 테스트")
     class signupTest {
         @Test
         @DisplayName("성공")
@@ -280,7 +282,7 @@ class MemberControllerTest {
     }
 
     @Nested
-    @DisplayName("로그인")
+    @DisplayName("로그인 API 테스트")
     class SignInRequest {
         @Test
         @DisplayName("성공")
@@ -434,5 +436,43 @@ class MemberControllerTest {
             actions.andExpect(status().isBadRequest());
         }
     }
+    @Nested
+    @DisplayName("로그아웃 API 테스트")
+    class LogoutTest{
+        @Test
+        @DisplayName("성공")
+        @WithCustomer(email = "dev@gmail.com")
+        void success() throws Exception {
+            //given
+
+            //when
+            ResultActions perform = mockMvc.perform(post("/member/logout")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            perform.andDo(print()).andExpectAll(
+                    status().isOk()
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 토큰이 없는 경우")
+        void fail_when_request_with_empty_token_return_bad_request() throws Exception {
+            //given
+
+            //when
+            ResultActions perform = mockMvc.perform(post("/member/logout")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            perform.andDo(print()).andExpectAll(
+                    status().isBadRequest()
+            );
+        }
+
+    }
+
 
 }

--- a/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
+++ b/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.store.reservation.member.service;
 
+import com.store.reservation.auth.refreshToken.exception.TokenErrorCode;
 import com.store.reservation.auth.refreshToken.exception.TokenException;
 import com.store.reservation.member.domain.MemberInformation;
 import com.store.reservation.member.domain.type.Role;
@@ -26,8 +27,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.store.reservation.auth.refreshToken.exception.TokenErrorCode.INVALID_ACCESS;
-import static com.store.reservation.auth.refreshToken.exception.TokenErrorCode.TOKEN_EXPIRED;
+import static com.store.reservation.auth.refreshToken.exception.TokenErrorCode.*;
 import static com.store.reservation.member.exception.MemberError.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -217,7 +217,7 @@ class MemberServiceTest {
     }
 
     @Nested
-    @DisplayName("로그아웃")
+    @DisplayName("로그아웃 테스트")
     class LogoutTest {
         @Test
         @DisplayName("성공")
@@ -228,5 +228,109 @@ class MemberServiceTest {
             memberService.logout(email);
             verify(jwtProvider, times(1)).deleteRefreshToken(anyString());
         }
+    }
+
+    @Nested
+    @DisplayName("접근 토큰 재발급 테스트")
+    class ReissueTest {
+
+        @Test
+        @DisplayName("성공 - 유효한 재발급 토큰과 요청자의 이메일 정보와 일치하고 요청 날짜 값이 null이 아닌 경우")
+        void success(){
+            // given
+            String expectedAccessToken = "newAccessToken";
+            String refreshToken = "validRefreshToken";
+            String email = "dev@gmail.com";
+            LocalDateTime today = LocalDateTime.now();
+            ReissueTokenDto reissueTokenDto = new ReissueTokenDto(email, today);
+
+            given(jwtProvider.reissue(anyString(), any(),any()))
+                    .willReturn(expectedAccessToken);
+
+            // when
+            String actualToken = memberService.reissue(refreshToken, reissueTokenDto);
+
+            // then
+            assertEquals(expectedAccessToken, actualToken);
+        }
+
+        @Test
+        @DisplayName("실패 - 만료된 재발급 토큰으로 재발급 요청하는 경우")
+        void fail_when_expired_refresh_token(){
+            // given
+            String refreshToken = "expiredRefreshToken";
+            String email = "dev@gmail.com";
+            LocalDateTime today = LocalDateTime.now();
+            ReissueTokenDto reissueTokenDto = new ReissueTokenDto(email, today);
+            TokenException expectedTokenException = new TokenException(NO_SUCH_TOKEN);
+            given(jwtProvider.reissue(anyString(), any(),any()))
+                    .willThrow(expectedTokenException);
+
+            // when
+            TokenException actualTokenException = assertThrows(TokenException.class, ()->memberService.reissue(refreshToken, reissueTokenDto));
+
+            // then
+            assertEquals(expectedTokenException.getErrorCode(), actualTokenException.getErrorCode());
+            assertEquals(expectedTokenException.getDescription(), actualTokenException.getDescription());
+        }
+
+        @Test
+        @DisplayName("실패 - 다른 사용자의 refresh token으로 재발급하려는 경우")
+        void fail_when_do_with_others_refresh_token(){
+            // given
+            String refreshToken = "expiredRefreshToken";
+            String email = "dev@gmail.com";
+            LocalDateTime today = LocalDateTime.now();
+            ReissueTokenDto reissueTokenDto = new ReissueTokenDto(email, today);
+            TokenException expectedTokenException = new TokenException(INVALID_ACCESS);
+            given(jwtProvider.reissue(anyString(), any(),any()))
+                    .willThrow(expectedTokenException);
+
+            // when
+            TokenException actualTokenException = assertThrows(TokenException.class,
+                    ()->memberService.reissue(refreshToken, reissueTokenDto));
+
+            // then
+            assertEquals(expectedTokenException.getErrorCode(), actualTokenException.getErrorCode());
+            assertEquals(expectedTokenException.getDescription(), actualTokenException.getDescription());
+        }
+
+        @Test
+        @DisplayName("실패 - 재발급 토큰 값이 없는 경우")
+        void fail_when_empty_refresh_token(){
+            // given
+            String refreshToken = "";
+            String email = "dev@gmail.com";
+            LocalDateTime today = LocalDateTime.now();
+            ReissueTokenDto reissueTokenDto = new ReissueTokenDto(email, today);
+            TokenException expectedTokenException = new TokenException(EMPTY_TOKEN);
+
+            // when
+            TokenException actualTokenException = assertThrows(TokenException.class, ()->memberService.reissue(refreshToken, reissueTokenDto));
+
+            // then
+            assertEquals(expectedTokenException.getErrorCode(), actualTokenException.getErrorCode());
+            assertEquals(expectedTokenException.getDescription(), actualTokenException.getDescription());
+        }
+
+        @Test
+        @DisplayName("실패 - 요청 날짜가 null인 경우")
+        void fail_when_request_date_is_null(){
+            // given
+            String refreshToken = "nonExpiredRefreshToken";
+            String email = "dev@gmail.com";
+            LocalDateTime today = null;
+            ReissueTokenDto reissueTokenDto = new ReissueTokenDto(email, today);
+            MemberRuntimeException expectedException = new MemberRuntimeException(TIME_EMPTY);
+
+            // when
+            MemberRuntimeException actualException = assertThrows(MemberRuntimeException.class,
+                    ()->memberService.reissue(refreshToken, reissueTokenDto));
+
+            // then
+            assertEquals(expectedException.getErrorCode(), actualException.getErrorCode());
+            assertEquals(expectedException.getDescription(), actualException.getDescription());
+        }
+
     }
 }

--- a/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
+++ b/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
@@ -1,8 +1,12 @@
 package com.store.reservation.member.service;
 
+import com.store.reservation.auth.refreshToken.exception.TokenException;
 import com.store.reservation.member.domain.MemberInformation;
 import com.store.reservation.member.domain.type.Role;
+import com.store.reservation.member.dto.ReissueTokenDto;
+import com.store.reservation.member.dto.SignInDto;
 import com.store.reservation.member.dto.SignUpDto;
+import com.store.reservation.member.dto.TokenDto;
 import com.store.reservation.member.exception.MemberError;
 import com.store.reservation.member.exception.MemberRuntimeException;
 import com.store.reservation.member.repository.MemberInformationRepository;
@@ -17,14 +21,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
+import static com.store.reservation.auth.refreshToken.exception.TokenErrorCode.INVALID_ACCESS;
+import static com.store.reservation.auth.refreshToken.exception.TokenErrorCode.TOKEN_EXPIRED;
+import static com.store.reservation.member.exception.MemberError.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -115,4 +125,94 @@ class MemberServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("로그인")
+    class LoginTest {
+        @Test
+        @DisplayName("성공 - 회원 가입한 상태이고 올바른 이메일과 패스워드를 입력했다.")
+        void success() {
+            LocalDateTime today = LocalDateTime.now();
+            SignInDto signInDto = SignInDto.builder()
+                    .email("dev@gmail.com")
+                    .password("12345!Qw")
+                    .today(today)
+                    .build();
+            MemberInformation memberInformation = MemberInformation.builder()
+                    .email(signInDto.getEmail())
+                    .password(signInDto.getPassword())
+                    .build();
+            String accessToken = "accessToken";
+            String refreshToken = "refreshToken";
+            given(memberInformationRepository.findByEmail(anyString())).willReturn(Optional.of(memberInformation));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+            given(jwtProvider.generateAccessToken(anyString(), any())).willReturn(accessToken);
+            given(jwtProvider.issueRefreshToken(anyString(), any())).willReturn(refreshToken);
+
+            TokenDto tokenDto = memberService.signIn(signInDto);
+
+            assertEquals(tokenDto.getAccessToken(), accessToken);
+            assertEquals(tokenDto.getRefreshToken(), refreshToken);
+        }
+
+        @Test
+        @DisplayName("실패 - 회원 가입한 적이 없는 경우")
+        void fail_because_have_not_signup() {
+            LocalDateTime today = LocalDateTime.now();
+            SignInDto signInDto = SignInDto.builder()
+                    .email("dev@gmail.com")
+                    .password("12345!Qw")
+                    .today(today)
+                    .build();
+            MemberRuntimeException expectedException = new MemberRuntimeException(NO_SUCH_MEMBER);
+            given(memberInformationRepository.findByEmail(anyString())).willThrow(expectedException);
+
+            MemberRuntimeException actualException = assertThrows(MemberRuntimeException.class, () -> memberService.signIn(signInDto));
+
+            assertEquals(expectedException.getErrorCode(), actualException.getErrorCode());
+            assertEquals(expectedException.getDescription(), actualException.getDescription());
+        }
+
+        @Test
+        @DisplayName("실패 - 비밀번호를 잘못 입력한 경우")
+        void fail_because_enter_wrong_password() {
+            LocalDateTime today = LocalDateTime.now();
+            SignInDto signInDto = SignInDto.builder()
+                    .email("dev@gmail.com")
+                    .password("wrong_password")
+                    .today(today)
+                    .build();
+            MemberInformation memberInformation = MemberInformation.builder()
+                    .email(signInDto.getEmail())
+                    .password(signInDto.getPassword())
+                    .build();
+            MemberRuntimeException expectedException = new MemberRuntimeException(PASSWORD_NOT_MATCH);
+            given(memberInformationRepository.findByEmail(anyString())).willReturn(Optional.of(memberInformation));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+            MemberRuntimeException actualException = assertThrows(MemberRuntimeException.class, () -> memberService.signIn(signInDto));
+
+            assertEquals(expectedException.getErrorCode(), actualException.getErrorCode());
+            assertEquals(expectedException.getDescription(), actualException.getDescription());
+        }
+
+        @Test
+        @DisplayName("실패 - 날짜 값이 비어있는 경우")
+        void fail_because_enter_time_empty() {
+            SignInDto signInDto = SignInDto.builder()
+                    .email("dev@gmail.com")
+                    .password("1234!Q1w")
+                    .today(null)
+                    .build();
+            MemberInformation memberInformation = MemberInformation.builder()
+                    .email(signInDto.getEmail())
+                    .password(signInDto.getPassword())
+                    .build();
+            MemberRuntimeException expectedException = new MemberRuntimeException(TIME_EMPTY);
+            given(memberInformationRepository.findByEmail(anyString())).willReturn(Optional.of(memberInformation));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+            MemberRuntimeException actualException = assertThrows(MemberRuntimeException.class, () -> memberService.signIn(signInDto));
+
+            assertEquals(expectedException.getErrorCode(), actualException.getErrorCode());
+            assertEquals(expectedException.getDescription(), actualException.getDescription());
+        }
+    }
 }

--- a/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
+++ b/storeReservation/src/test/java/com/store/reservation/member/service/MemberServiceTest.java
@@ -126,7 +126,7 @@ class MemberServiceTest {
     }
 
     @Nested
-    @DisplayName("로그인")
+    @DisplayName("로그인 기능 테스트")
     class LoginTest {
         @Test
         @DisplayName("성공 - 회원 가입한 상태이고 올바른 이메일과 패스워드를 입력했다.")
@@ -213,6 +213,20 @@ class MemberServiceTest {
 
             assertEquals(expectedException.getErrorCode(), actualException.getErrorCode());
             assertEquals(expectedException.getDescription(), actualException.getDescription());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class LogoutTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            String email = "dev@gmail.com";
+
+            doNothing().when(jwtProvider).deleteRefreshToken(anyString());
+            memberService.logout(email);
+            verify(jwtProvider, times(1)).deleteRefreshToken(anyString());
         }
     }
 }


### PR DESCRIPTION
## Summary
- 로그인, 로그아웃, 접근 토큰 재발급 기능 테스트
- 접근 토큰 재발급 기능 테스트하던 중 구조 수정

## Task Description
### 테스트
#### 로그인
  - 성공
    - 회원 가입했으며 이메일, 패스워드와 요청 날짜 정보가 올바르게 입력된 경우
  - 실패
    - 회원 가입한 적 없는 경우, 회원 가입 시 입력한 이메일이 아닌 경우
    - 회원 가입 시 입력한 비밀번호가 아닌 비밀번호를 입력한 경우
    - 비밀번호 형식이 잘못된 경우
    - 이메일을 잘못 입력한 경우
    - 날짜 정보를 입력하지 않은 경우
#### 로그아웃
  - 성공
    - access token을 요청 헤더에 포함하여 요청한 경우
  - 실패
    - access token을 요청 헤더에 포함하지 않고 요청한 경우 
#### 접근 토큰 재발급
  - 성공
    - refresh token이 유효하고 요청한 사용자의 refresh token인 경우
  - 실패
    - refresh token이 만료된 경우
    - 요청한 사용자의 refresh token이 아닌 경우
    - 요청 날짜가 누락된 경우
### 접근 토큰 재발급 기능 구조 수정
#### Before
- MemberService에서 재발급에 필요한 정보들을 직접적으로 사용
- 재발급과 관련된 로직은 토큰에 대한 책임을 가지고 있는 JwtProvider로 은닉하여 재발급 로직 수정이 필요하더라도 MemberService는 영향을 받지 않도록 하기 위해서 책임을 이관  
#### After
- JwtProvider로 책임을 이관하고 MemberService 입장에서는 JwtProvider에 재발급 요청을 위임하도록 수정

![image](https://github.com/gomljo/storeReservation/assets/58705161/ab33b397-88e8-416b-a32e-db891efa96e9)

## Issues
#22 #23 #24 